### PR TITLE
Botany Reverts/Rebalance

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3456,4 +3456,8 @@
 #include "monkestation\code\modules\clothing\masks\miscellaneous.dm"
 #include "monkestation\code\modules\clothing\suits\labcoat.dm"
 #include "monkestation\code\modules\clothing\under\costume.dm"
+#include "monkestation\code\modules\hydroponics\plant_genes.dm"
+#include "monkestation\code\modules\hydroponics\grown\berries.dm"
+#include "monkestation\code\modules\research\designs\biogenerator_designs.dm"
+#include "monkestation\code\modules\research\techweb\_techweb.dm"
 // END_INCLUDE

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -16,13 +16,21 @@
 	var/productivity = 0
 	var/max_items = 40
 	var/datum/techweb/stored_research
-	var/list/show_categories = list("Food", "Botany Chemicals", "Organic Materials")
+	//MonkeStation Edit Start (Adds new category)
+	var/list/show_categories = list("Food", "Botany Chemicals", "Organic Materials", "Clothing")
+	//MonkeStation Edit End
 	/// Currently selected category in the UI
 	var/selected_cat
 
 /obj/machinery/biogenerator/Initialize()
 	. = ..()
-	stored_research = new /datum/techweb/specialized/autounlocking/biogenerator
+	//MonkeStation Changes Start
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		var/datum/techweb/specialized/autounlocking/biogenerator/bio_parts = new
+		bio_parts.update_biogen(M.rating)
+		stored_research = bio_parts
+		ui_update()
+	//MonkeStation Changes End
 	create_reagents(1000)
 
 /obj/machinery/biogenerator/Destroy()
@@ -56,6 +64,12 @@
 		max_storage = 40 * B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		E += M.rating
+		//MonkeStation Changes Start
+		var/datum/techweb/specialized/autounlocking/biogenerator/bio_parts = new
+		bio_parts.update_biogen(M.rating)
+		stored_research = bio_parts
+		ui_update()
+		//MonkeStation Changes End
 	efficiency = E
 	productivity = P
 	max_items = max_storage
@@ -190,7 +204,9 @@
 			points += 1 * productivity
 			ui_update()
 		else
-			points += I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 10 * productivity
+			//MonkeStation Edit Start (Rounds income)
+			points += round(I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 10 * productivity)
+			//MonkeStation Edit End
 			ui_update()
 		qdel(I)
 	if(S)
@@ -211,7 +227,9 @@
 		return FALSE
 	else
 		if(remove_points)
-			points -= materials[getmaterialref(/datum/material/biomass)]*multiplier/efficiency
+		//MonkeStation Edit Start (Round costs)
+			points -= round(materials[getmaterialref(/datum/material/biomass)]*multiplier/efficiency)
+		//MonkeStation Edit End
 			ui_update()
 		update_icon()
 		return TRUE
@@ -317,7 +335,9 @@
 			cat["items"] += list(list(
 				"id" = D.id,
 				"name" = D.name,
-				"cost" = D.materials[getmaterialref(/datum/material/biomass)]/efficiency,
+				//MonkeStation Edit Start(Rounds price)
+				"cost" = round(D.materials[getmaterialref(/datum/material/biomass)]/efficiency),
+				//MonkeStation Edit End
 			))
 		data["categories"] += list(cat)
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -117,10 +117,17 @@
 	if(seed)
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
-	reagents.reaction(T)
-	for(var/A in T)
-		reagents.reaction(A)
-	qdel(src)
+	//MonkeStation Edit Start
+	//Re-adds Separated Chemicals and all that it needs
+	if(!seed.get_gene(/datum/plant_gene/trait/noreact))
+		reagents.reaction(T)
+		for(var/A in T)
+			reagents.reaction(A)
+		qdel(src)
+	if(seed.get_gene(/datum/plant_gene/trait/noreact))
+		visible_message("<span class='warning'>[src] crumples, and bubbles ominously as its contents mix.</span>")
+		addtimer(CALLBACK(src, .proc/squashreact), 20)
+	//MonkeStation Edit End
 
 /obj/item/reagent_containers/food/snacks/grown/proc/squashreact()
 	for(var/datum/plant_gene/trait/trait in seed.genes)

--- a/monkestation/code/modules/hydroponics/grown/berries.dm
+++ b/monkestation/code/modules/hydroponics/grown/berries.dm
@@ -1,0 +1,2 @@
+/obj/item/seeds/berry/glow
+	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/noreact)

--- a/monkestation/code/modules/hydroponics/plant_genes.dm
+++ b/monkestation/code/modules/hydroponics/plant_genes.dm
@@ -1,0 +1,11 @@
+/datum/plant_gene/trait/noreact
+	// Makes plant reagents not react until squashed.
+	name = "Separated Chemicals"
+
+/datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	ENABLE_BITFIELD(G.reagents.flags, NO_REACT)
+
+/datum/plant_gene/trait/noreact/on_squashreact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
+	G.reagents.handle_reactions()

--- a/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,0 +1,156 @@
+//The following is all part of the botany chemical rebalance
+/datum/reagent/vaccine
+	random_unrestricted = FALSE //This does nothing without data, so don't synth it.
+
+/datum/reagent/fuel/unholywater
+	can_synth = FALSE //Far too powerful for botany
+
+/datum/reagent/mutationtoxin/felinid
+	can_synth = TRUE //The following mutation toxins, excluding golem, are all possible to get through the already existing Unstable Mutation Toxin
+
+/datum/reagent/mutationtoxin/lizard
+	can_synth = TRUE
+
+/datum/reagent/mutationtoxin/fly
+	can_synth = TRUE
+
+/datum/reagent/mutationtoxin/moth
+	can_synth = TRUE
+
+/datum/reagent/mutationtoxin/apid
+	can_synth = TRUE
+
+/datum/reagent/mutationtoxin/squid
+	can_synth = TRUE
+
+/datum/reagent/mutationtoxin/skeleton
+	can_synth = TRUE //Roundstart species
+
+/datum/reagent/mutationtoxin/golem
+	can_synth = TRUE //Non-dangerous chem
+
+//Unrestricting base chemicals
+
+/datum/reagent/water
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/oxygen
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/copper
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/nitrogen
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/hydrogen
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/potassium
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/mercury
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/sulfur
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/carbon
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/chlorine
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/fluorine
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/sodium
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/phosphorus
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/lithium
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/iron
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/gold
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/silver
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/uranium/radium
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/aluminium
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/silicon
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/fuel
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/stable_plasma
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/iodine
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/bromine
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+//End of chem bases
+
+/datum/reagent/snail
+	can_synth = TRUE
+
+/datum/reagent/smart_foaming_agent
+	random_unrestricted = TRUE
+
+//Virology chem start
+//These have no real point
+
+/datum/reagent/medicine/synaptizine/synaptizinevirusfood
+	can_synth = FALSE
+
+/datum/reagent/toxin/plasma/plasmavirusfood
+	can_synth = FALSE
+
+/datum/reagent/uranium/uraniumvirusfood
+	can_synth = FALSE
+
+/datum/reagent/uranium/uraniumvirusfood/stable
+	can_synth = FALSE
+
+/datum/reagent/consumable/laughter/laughtervirusfood
+	can_synth = FALSE
+
+//Virology chem end

--- a/monkestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1,0 +1,24 @@
+//The following is all part of the botany chemical rebalance
+/datum/reagent/toxin/lexorin
+	can_synth = FALSE //Extremely deadly
+
+/datum/reagent/toxin/bungotoxin
+	can_synth = FALSE //A bit OP to directly have in a plant
+
+/datum/reagent/toxin/initropidril
+	can_synth = FALSE //Too strong for botany. 25% chance a tick to really ruin your day.
+
+/datum/reagent/toxin/pancuronium
+	can_synth = FALSE //Too strong for botany. Ten cycles and permastunned
+
+/datum/reagent/toxin/sulfonal
+	can_synth = FALSE //Too strong for botany. This stuff removes people from the round outright
+
+/datum/reagent/toxin/coniine
+	can_synth = FALSE //Too strong for botany. Kills in no time
+
+/datum/reagent/toxin/curare
+	can_synth = FALSE //Too strong for botany. 6 second stuns?
+
+/datum/reagent/toxin/leaper_venom
+	can_synth = FALSE //5 toxin a tick

--- a/monkestation/code/modules/research/designs/biogenerator_designs.dm
+++ b/monkestation/code/modules/research/designs/biogenerator_designs.dm
@@ -1,0 +1,265 @@
+///////////////////////////////////
+///////Biogenerator Designs ///////
+///////////////////////////////////
+
+//MonkeStation changes:
+//Adds 4 tiers to the biogenerator designs
+
+/datum/design/milk
+	category = list("initial","Food")
+
+/datum/design/cream
+	category = list("initial","Food")
+
+/datum/design/milk_carton
+	category = list("tier_two","Food")
+
+/datum/design/cream_carton
+	category = list("tier_two","Food")
+
+/datum/design/black_pepper
+	category = list("initial","Food")
+
+/datum/design/pepper_mill
+	category = list("tier_two","Food")
+
+/datum/design/enzyme
+	category = list("tier_two","Food")
+
+/datum/design/universal_enzyme
+	name = "Universal Enzyme Bottle"
+	id = "enzyme_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 50)
+	build_path = /obj/item/reagent_containers/food/condiment/enzyme
+	make_reagents = list()
+	category = list("tier_three","Food")
+
+/datum/design/flour_sack
+	category = list("tier_two","Food")
+
+/datum/design/sugar_sack
+	category = list("tier_two","Food")
+
+/datum/design/donk_pocket
+	name = "Plain Donk Pocket"
+	id = "donk_pocket"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 200)
+	build_path = /obj/item/reagent_containers/food/snacks/donkpocket
+	category = list("tier_two","Food")
+
+/datum/design/monkey_cube
+	category = list("tier_three", "Food")
+
+/datum/design/strange_seeds
+	name = "Pack of Strange Seeds"
+	id = "strange_seed"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 7500) //Unlocked only at Tier 3/4 parts now. Cost of 2500/1875 biomass.
+	build_path = /obj/item/seeds/random
+	category = list("tier_three", "Food")
+
+/datum/design/ez_nut
+	category = list("initial","Botany Chemicals")
+
+/datum/design/l4z_nut
+	category = list("tier_two","Botany Chemicals")
+
+/datum/design/rh_nut
+	category = list("tier_three","Botany Chemicals")
+
+/datum/design/weed_killer
+	category = list("tier_two","Botany Chemicals")
+
+/datum/design/pest_spray
+	category = list("tier_two","Botany Chemicals")
+
+/datum/design/botany_bottle
+	category = list("initial", "Botany Chemicals")
+
+/datum/design/medical_spray
+	name = "Empty Medical Spray"
+	id = "medical_spray"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 10000)
+	build_path = /obj/item/reagent_containers/medspray
+	category = list("tier_three","Botany Chemicals")
+
+/datum/design/spray_bottle
+	name = "Empty Spray Bottle"
+	id = "spray_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 10000)
+	build_path = /obj/item/reagent_containers/spray
+	category = list("tier_three","Botany Chemicals")
+
+/datum/design/paper_bin
+	name = "Paper Bin"
+	id = "paper"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 100)
+	build_path = /obj/item/paper_bin
+	category = list("initial","Organic Materials")
+
+/datum/design/paper_bin_colored
+	name = "Construction Paper Bin"
+	id = "paper_colored"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 100)
+	build_path = /obj/item/paper_bin/construction
+	category = list("initial","Organic Materials")
+
+/datum/design/cloth
+	category = list("tier_three","Organic Materials")
+
+/datum/design/cardboard
+	category = list("tier_two","Organic Materials")
+
+/datum/design/leather
+	category = list("tier_three","Organic Materials")
+
+/datum/design/wig
+	name = "Random Wig"
+	id = "wig"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 4000)
+	build_path = /obj/item/clothing/head/wig/random
+	category = list("tier_three","Clothing")
+
+/datum/design/bible
+	name = "Bible"//All SS13 players need this
+	id = "bible"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 4000)
+	build_path = /obj/item/storage/book/bible
+	category = list("tier_three","Organic Materials")
+
+/datum/design/toolbelt
+	category = list("tier_three","Clothing")
+
+/datum/design/secbelt
+	category = list("tier_three","Clothing")
+
+/datum/design/medbelt
+	category = list("tier_three","Clothing")
+
+/datum/design/janibelt
+	category = list("tier_three","Clothing")
+
+/datum/design/s_holster
+	category = list("tier_three","Clothing")
+
+/datum/design/wallet
+	name = "Wallet"
+	id = "wallet"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/storage/wallet
+	category = list("tier_three","Clothing")
+
+/datum/design/rice_hat
+	category = list("initial","Clothing")
+
+/datum/design/carton_soy_milk
+	category = list("tier_two","Food")
+
+//Tier four rewards
+//Remember, everything is 1/4 the price at this tier. Go high.
+
+/datum/design/armor_vest
+	name = "Light Armor Vest"
+	id = "armor_vest"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/suit/armor/vest
+	category = list("tier_four","Clothing")
+
+/datum/design/mime_mask
+	name = "Mime Mask"
+	id = "mime_mask"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/mask/gas/mime
+	category = list("tier_four","Clothing")
+
+/datum/design/clown_mask
+	name = "Clown Mask"
+	id = "clown_mask"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/mask/gas/clown_hat
+	category = list("tier_four","Clothing")
+
+/datum/design/clown_shoes
+	name = "Clown Shoes"
+	id = "clown_shoes"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/shoes/clown_shoes
+	category = list("tier_four","Clothing")
+
+/datum/design/EVA_helmet
+	name = "Space Helmet"
+	id = "space_helmet"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/head/helmet/space/eva
+	category = list("tier_four","Clothing")
+
+/datum/design/EVA_suit
+	name = "Space Suit"
+	id = "space_suit"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/suit/space/eva
+	category = list("tier_four","Clothing")
+
+/datum/design/tactical_vest
+	name = "Snacktical Vest"
+	id = "snack_vest"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/storage/belt/military/snack
+	category = list("tier_four","Clothing")
+
+/datum/design/champion_belt
+	name = "Championship Belt"
+	id = "champ_belt"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/storage/belt/champion
+	category = list("tier_four","Clothing")
+
+/datum/design/chef_hat
+	name = "Chef Hat"
+	id = "chef_hat"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/clothing/head/chefhat
+	category = list("tier_four","Clothing")
+
+/datum/design/fanny_pack
+	name = "Fannypack"
+	id = "fanny_pack"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 20000)
+	build_path = /obj/item/storage/belt/fannypack
+	category = list("tier_four","Clothing")
+
+
+/datum/design/plastic
+	name = "Plastic Sheets"
+	id = "plastic_sheets"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 4000)
+	build_path = /obj/item/stack/sheet/plastic
+	category = list("tier_four","Organic Materials")
+
+/datum/design/greyslime //Late-game DIY xenobio
+	name = "Grey Slime Core"
+	id = "greyslime"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 100000)
+	build_path = /obj/item/slime_extract/grey
+	category = list("tier_four","Organic Materials")

--- a/monkestation/code/modules/research/techweb/_techweb.dm
+++ b/monkestation/code/modules/research/techweb/_techweb.dm
@@ -1,0 +1,15 @@
+/datum/techweb/specialized/autounlocking/biogenerator/proc/update_biogen(var/tier)
+	design_autounlock_categories = tier
+	switch(tier)
+		if(1)
+			design_autounlock_categories = list("initial")
+		if(2)
+			design_autounlock_categories = list("initial", "tier_two")
+		if(3)
+			design_autounlock_categories = list("initial", "tier_two", "tier_three")
+		if(4)
+			design_autounlock_categories = list("initial", "tier_two", "tier_three", "tier_four")
+	autounlock()
+
+/datum/techweb/specialized/autounlocking/biogenerator/New()
+	return //Prevents a double update.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR restores Strange Seeds, Separated Chemicals, modifies the Strange Seed chemical list and gives recipe tiers to Biogenerators.

The chemicals removed from the list are chemicals that are either pointless, or deadly enough to be too strong to have an infinite supply of. One shouldn't just grow an entire infinite poison kit for free!

## Why It's Good For The Game

The primary issue with Strange Seeds and Separated chemicals is the ease and speed that a player could create highly powerful weaponry. This change adds delays to even starting the chemical hunt, as well as making deadly chemicals much rarer.
The biogenerator changes give botanists more 'toys' to play with and possibly distribute among the crew, rather than only making things for themselves.

## Changelog
:cl:
add: Restores Strange Seeds and adds a number of safer chemicals to their pool
add: Restores Separated Chemicals
add: Adds a number of new items to Biogenerators
del: Removed a number of dangerous chemicals from the strange seed pool
balance: Biogenerators now have part tiers that unlock various items for generation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
