### PR TITLE
Blood Harvesting but for real this time

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -37,18 +37,21 @@
 			if(!..())
 				break
 
-/datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+/datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/blood_filter/filter, datum/surgery/surgery, default_display_results = FALSE) //Monkestation edit
 	if(target.reagents.total_volume)
 		for(var/blood_chem in target.reagents.reagent_list)
 			var/datum/reagent/chem = blood_chem
-			target.reagents.remove_reagent(chem.type, min(chem.volume * 0.22, 10)) //Removes more reagent for higher amounts
-		display_results(user, target, "<span class='notice'>[tool] pings as it finishes filtering [target]'s blood.</span>",
-			"<span class='notice'>[tool] pings as it stops pumping your blood.</span>",
-			"[tool] pings as it stops pumping.")
+			var/transfer_amount = min(chem.volume * 0.22, 10)
+			target.reagents.remove_reagent(chem.type, transfer_amount) //Removes more reagent for higher amounts //Monkestation edit start
+			if(filter.beakers.len > 0)
+				filter.beakers[1].reagents.add_reagent(chem.type, min(transfer_amount, filter.beakers[1].volume - filter.beakers[1].reagents.total_volume))
+		display_results(user, target, "<span class='notice'>[filter] pings as it finishes filtering [target]'s blood.</span>",
+			"<span class='notice'>[filter] pings as it stops pumping your blood.</span>",
+			"[filter] pings as it stops pumping.")
 	else
-		display_results(user, target, "<span class='notice'>[tool] flashes, [target]'s blood is clean.</span>",
-			"<span class='notice'>[tool] flashes, your blood is clean.</span>",
-			"[tool] has no chemcials to filter.")
+		display_results(user, target, "<span class='notice'>[filter] flashes, [target]'s blood is clean.</span>",
+			"<span class='notice'>[filter] flashes, your blood is clean.</span>",
+			"[filter] has no chemcials to filter.") //Monkestation edit end
 	if(istype(surgery, /datum/surgery/blood_filter))
 		var/datum/surgery/blood_filter/the_surgery = surgery
 		the_surgery.antispam = TRUE

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -43,8 +43,8 @@
 			var/datum/reagent/chem = blood_chem
 			var/transfer_amount = min(chem.volume * 0.22, 10)
 			target.reagents.remove_reagent(chem.type, transfer_amount) //Removes more reagent for higher amounts //Monkestation edit start
-			if(filter.beakers.len > 0)
-				filter.beakers[1].reagents.add_reagent(chem.type, min(transfer_amount, filter.beakers[1].volume - filter.beakers[1].reagents.total_volume))
+			if(filter.beaker)
+				filter.beaker.reagents.add_reagent(chem.type, min(transfer_amount, filter.beaker.volume - filter.beaker.reagents.total_volume))
 		display_results(user, target, "<span class='notice'>[filter] pings as it finishes filtering [target]'s blood.</span>",
 			"<span class='notice'>[filter] pings as it stops pumping your blood.</span>",
 			"[filter] pings as it stops pumping.")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -93,7 +93,58 @@
 	attack_verb = list("pumps", "siphons")
 	tool_behaviour = TOOL_BLOODFILTER
 	toolspeed = 1
+	var/load_sound = 'sound/weapons/shotguninsert.ogg' //Monkestation edit start
+	var/list/obj/item/reagent_containers/glass/beakers = list()
+	var/max_beakers = 1
 
+/obj/item/blood_filter/handle_atom_del(atom/A)
+	. = ..()
+	if(A in beakers)
+		beakers.Remove(A)
+
+/obj/item/blood_filter/examine(mob/user)
+	. = ..()
+	if(beakers.len > 0)
+		. += "It has a [beakers[1].name] loaded."
+		if(beakers[1].reagents.total_volume)
+			. += "<span class='notice'>It has [beakers[1].reagents.total_volume] unit\s of reagents.</span>"
+		else
+			. += "<span class='danger'>It's empty.</span>"
+	else
+		. += "It has a receptacle that can hold a beaker."
+
+/obj/item/blood_filter/attack_self(mob/living/user)
+	if(!beakers.len)
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
+		return 0
+
+	var/obj/item/reagent_containers/glass/S = beakers[beakers.len]
+
+	if(!S)
+		return FALSE
+	user.put_in_hands(S)
+
+	beakers.Remove(S)
+	update_icon()
+	to_chat(user, "<span class='notice'>You unload [S] from \the [src].</span>")
+
+	return TRUE
+
+/obj/item/blood_filter/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
+	if(istype(A, /obj/item/reagent_containers/glass))
+		if(beakers.len < 1)
+			if(!user.transferItemToLoc(A, src))
+				return FALSE
+			to_chat(user, "<span class='notice'>You load [A] into \the [src].</span>")
+			beakers += A
+			update_icon()
+			playsound(loc, load_sound, 40)
+			return TRUE
+		else
+			to_chat(user, "<span class='warning'>[src] cannot hold more beakers!</span>")
+	return FALSE
+
+//Monkestation edit end
 
 /obj/item/surgicaldrill
 	name = "surgical drill"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -94,54 +94,51 @@
 	tool_behaviour = TOOL_BLOODFILTER
 	toolspeed = 1
 	var/load_sound = 'sound/weapons/shotguninsert.ogg' //Monkestation edit start
-	var/list/obj/item/reagent_containers/glass/beakers = list()
-	var/max_beakers = 1
+	var/list/obj/item/reagent_containers/glass/beaker = null
 
 /obj/item/blood_filter/handle_atom_del(atom/A)
 	. = ..()
-	if(A in beakers)
-		beakers.Remove(A)
+	if(beaker)
+		qdel(beaker)
 
 /obj/item/blood_filter/examine(mob/user)
 	. = ..()
-	if(beakers.len > 0)
-		. += "It has a [beakers[1].name] loaded."
-		if(beakers[1].reagents.total_volume)
-			. += "<span class='notice'>It has [beakers[1].reagents.total_volume] unit\s of reagents.</span>"
+	if(beaker)
+		. += "It has a [beaker] loaded."
+		if(beaker.reagents.total_volume)
+			. += "<span class='notice'>It has [beaker.reagents.total_volume] unit\s of reagents.</span>"
 		else
 			. += "<span class='danger'>It's empty.</span>"
 	else
 		. += "It has a receptacle that can hold a beaker."
 
 /obj/item/blood_filter/attack_self(mob/living/user)
-	if(!beakers.len)
+	if(!beaker)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return 0
 
-	var/obj/item/reagent_containers/glass/S = beakers[beakers.len]
+	var/obj/item/reagent_containers/glass/S = beaker
 
 	if(!S)
 		return FALSE
 	user.put_in_hands(S)
-
-	beakers.Remove(S)
-	update_icon()
 	to_chat(user, "<span class='notice'>You unload [S] from \the [src].</span>")
+	beaker = null
 
 	return TRUE
 
 /obj/item/blood_filter/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/glass))
-		if(beakers.len < 1)
+		if(beaker)
+			to_chat(user, "<span class='warning'>[src] is already loaded!</span>")
+		else
 			if(!user.transferItemToLoc(A, src))
 				return FALSE
 			to_chat(user, "<span class='notice'>You load [A] into \the [src].</span>")
-			beakers += A
+			beaker = A
 			update_icon()
 			playsound(loc, load_sound, 40)
 			return TRUE
-		else
-			to_chat(user, "<span class='warning'>[src] cannot hold more beakers!</span>")
 	return FALSE
 
 //Monkestation edit end


### PR DESCRIPTION
… on examine, store reagents as they get filtered from blood

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a 1-beaker magazine to the blood filter. You can load any type of beaker into it. When performing the "filter blood" surgery, if there's a beaker loaded into the blood filter, it will fill with the chemicals that get filtered from the patient's blood. If the beaker is missing or full, the procedure happens as normal before this change. You can see the loaded beaker and the amount of reagents (but not specifics) by examining the filter.

## Why It's Good For The Game

Currently there's no way to preserve reagents that are extracted from a patient's blood. This could unlock a lot of shenanigans, as well as complications. For instance, a very risky and messy way to extract the chems from maint pills. A concern if the patient contains unreacted pyrotechnic chemicals. Who know what horrible things will be thought up! It creates more complexity and interest. It also opens avenues for potential future additions involving chems in someone's system.

## Changelog
:cl:
add: Blood filters can now load any beaker. When filtering blood they will store the filtered reagents in the beaker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
