### PR TITLE
Rideable Water and Fuel Tanks!

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -8,6 +8,8 @@
 	anchored = FALSE
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	can_buckle = 1 //Monkestation edit
+	buckle_lying = 0 //Monkestation edit
 
 
 
@@ -47,6 +49,8 @@
 	update_icon()
 	GLOB.poi_list |= src
 	previous_level = get_security_level()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding) //Monkestation edit
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7))) //Monkestation edit
 
 /obj/machinery/nuclearbomb/Destroy()
 	safety = FALSE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -44,12 +44,36 @@
 	name = "water tank"
 	desc = "A water tank."
 	icon_state = "water"
+	can_buckle = 1 //Monkestation edit start
+	buckle_lying = 0
+
+/obj/structure/reagent_dispensers/watertank/Initialize(mapload)
+	. = ..()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
+
+/obj/structure/reagent_dispensers/watertank/Moved()
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, 1)//Monkestation edit end
 
 /obj/structure/reagent_dispensers/watertank/high
 	name = "high-capacity water tank"
 	desc = "A highly pressurized water tank made to hold gargantuan amounts of water."
 	icon_state = "water_high" //I was gonna clean my room...
 	tank_volume = 100000
+	can_buckle = 1 //Monkestation edit start
+	buckle_lying = 0
+
+/obj/structure/reagent_dispensers/watertank/high/Initialize(mapload)
+	. = ..()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
+
+/obj/structure/reagent_dispensers/watertank/high/Moved()
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, 1)//Monkestation edit end
 
 /obj/structure/reagent_dispensers/foamtank
 	name = "firefighting foam tank"
@@ -57,12 +81,36 @@
 	icon_state = "foam"
 	reagent_id = /datum/reagent/firefighting_foam
 	tank_volume = 500
+	can_buckle = 1 //Monkestation edit start
+	buckle_lying = 0
+
+/obj/structure/reagent_dispensers/foamtank/Initialize(mapload)
+	. = ..()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
+
+/obj/structure/reagent_dispensers/foamtank/Moved()
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, 1)//Monkestation edit end
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fuel tank"
 	desc = "A tank full of industrial welding fuel. Do not consume."
 	icon_state = "fuel"
 	reagent_id = /datum/reagent/fuel
+	can_buckle = 1 //Monkestation edit start
+	buckle_lying = 0
+
+/obj/structure/reagent_dispensers/fueltank/Initialize(mapload)
+	. = ..()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
+
+/obj/structure/reagent_dispensers/fueltank/Moved()
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, 1)//Monkestation edit end
 
 /obj/structure/reagent_dispensers/fueltank/boom()
 	var/light_explosion_range = CLAMP(round(reagents.get_reagent_amount(/datum/reagent/fuel)/200, 1), 1, 5) //explosion range should decrease when there is less fuel in the tank


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability to buckle to water tanks, fuel tanks, and foam tanks.  You can propel yourself with a fire extinguisher while riding one.  They also make sound while moving like an office chair.  It uses the vehicle component to give a proper graphical offset while you're on it.

## Why It's Good For The Game

Enables more silly shenanigans! You can leap onto a tank to shield it from being blown up!  You can ride own down the hall threatening people!  You can strap yourself to a water tank to be an extremely silly firefighter!

## Changelog
:cl:
add: Water and fuel tanks can now be ridden, and make noise when being moved! 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
