### PR TITLE
Stowaway Trait

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3447,6 +3447,7 @@
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "monkestation\code\_HELPERS\unsorted.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\fermentation.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\gateway.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\goat.dm"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -278,6 +278,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_GRABWEAKNESS		"grab_weakness"
 //MonkeStation Edit Start
 #define TRAIT_JAILBIRD			"jailbird"
+#define TRAIT_STOWAWAY			"stowaway"
 //MonkeStation Edit End
 
 ///Trait applied to turfs when an atmos holosign is placed on them. It will stop firedoors from closing.

--- a/monkestation/code/_HELPERS/unsorted.dm
+++ b/monkestation/code/_HELPERS/unsorted.dm
@@ -1,13 +1,13 @@
 //Used to get a random untouched locker, created for the Stowaway trait
-/proc/get_untouched_unlocked_closed_locker() //I've seen worse proc names
+/proc/get_unlocked_closed_locker() //I've seen worse proc names
 	var/list/picked_lockers = list()
 	var/turf/object_location
-	for(var/obj/structure/closet/find_closet in world)				//Get crates
-		if(!istype(find_closet,/obj/structure/closet/secure_closet))//But not the locked crates
-			object_location = get_turf(find_closet) 				//Get the location it's at
-			if(object_location) 									//If it can't read a Z on the next step, it will error out. Needs a separate check.
-				if(is_station_level(object_location.z) && !find_closet.opened && !find_closet.GetComponent(/datum/component/forensics)) //Untouched, on the station and closed.
+	for(var/obj/structure/closet/find_closet in world)
+		if(!istype(find_closet,/obj/structure/closet/secure_closet))
+			object_location = get_turf(find_closet)
+			if(object_location) //If it can't read a Z on the next step, it will error out. Needs a separate check.
+				if(is_station_level(object_location.z) && !find_closet.opened) //On the station and closed.
 					picked_lockers += find_closet
-	if(picked_lockers) //Catch edge cases where there somehow is no locker.
+	if(picked_lockers)
 		return pick(picked_lockers)
 	return FALSE

--- a/monkestation/code/_HELPERS/unsorted.dm
+++ b/monkestation/code/_HELPERS/unsorted.dm
@@ -1,0 +1,13 @@
+//Used to get a random untouched locker, created for the Stowaway trait
+/proc/get_untouched_unlocked_closed_locker() //I've seen worse proc names
+	var/list/picked_lockers = list()
+	var/turf/object_location
+	for(var/obj/structure/closet/find_closet in world)				//Get crates
+		if(!istype(find_closet,/obj/structure/closet/secure_closet))//But not the locked crates
+			object_location = get_turf(find_closet) 				//Get the location it's at
+			if(object_location) 									//If it can't read a Z on the next step, it will error out. Needs a separate check.
+				if(is_station_level(object_location.z) && !find_closet.opened && !find_closet.GetComponent(/datum/component/forensics)) //Untouched, on the station and closed.
+					picked_lockers += find_closet
+	if(picked_lockers) //Catch edge cases where there somehow is no locker.
+		return pick(picked_lockers)
+	return FALSE

--- a/monkestation/code/_HELPERS/unsorted.dm
+++ b/monkestation/code/_HELPERS/unsorted.dm
@@ -1,4 +1,4 @@
-//Used to get a random untouched locker, created for the Stowaway trait
+//Used to get a random closed and non-secure locker on the station z-level, created for the Stowaway trait.
 /proc/get_unlocked_closed_locker() //I've seen worse proc names
 	var/list/picked_lockers = list()
 	var/turf/object_location

--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -15,3 +15,30 @@
 		GLOB.data_core.addCrime(R.fields["id"], crime)
 		R.fields["criminal"] = "Arrest"
 		H.sec_hud_set_security_status()
+
+/datum/quirk/stowaway
+	name = "Stowaway"
+	desc = "You're a station stowaway with no ID card that wakes up inside a random locker, who knows where you'll end up?"
+	value = -2 //More powerful than Jailbird, this WILL cause you issues throughout a round.
+
+/datum/quirk/stowaway/on_spawn()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.Sleeping(5 SECONDS, TRUE, TRUE) //This is both flavorful and gives time for the rest of the code to work.
+	var/obj/item/card/id/trashed = H.get_item_by_slot(ITEM_SLOT_ID) //No ID
+	qdel(trashed)
+	if(prob(20))
+		H.drunkenness = 50 //What did I DO last night?
+	var/obj/structure/closet/selected_closet = get_untouched_unlocked_closed_locker() //Find your new home
+	if(selected_closet)
+		H.forceMove(selected_closet) //Move in
+
+
+/datum/quirk/stowaway/post_add()
+	. = ..()
+	spawn(4 SECONDS) //Gives enough time for the data_core entry to get created
+		var/mob/living/carbon/human/H = quirk_holder
+		var/perpname = H.name
+		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.general)
+		qdel(R)
+		to_chat(H, "<span class='boldnotice'>You've awoken to find yourself inside [GLOB.station_name] without identification!</span>")

--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -19,7 +19,7 @@
 /datum/quirk/stowaway
 	name = "Stowaway"
 	desc = "You're a station stowaway with no ID card that wakes up inside a random locker, who knows where you'll end up?"
-	value = -2 //More powerful than Jailbird, this WILL cause you issues throughout a round.
+	value = -2
 
 /datum/quirk/stowaway/on_spawn()
 	. = ..()
@@ -29,7 +29,7 @@
 	qdel(trashed)
 	if(prob(20))
 		H.drunkenness = 50 //What did I DO last night?
-	var/obj/structure/closet/selected_closet = get_untouched_unlocked_closed_locker() //Find your new home
+	var/obj/structure/closet/selected_closet = get_unlocked_closed_locker() //Find your new home
 	if(selected_closet)
 		H.forceMove(selected_closet) //Move in
 


### PR DESCRIPTION
## About The Pull Request

Adds the Stowaway Trait, causing players to spawn with no ID, no records on the manifest and inside a random station crate/locker.
This also includes a global proc to return an untouched and unlocked locker for whatever purpose.

## Why It's Good For The Game

As with Jailbird, this trait should provide a number of unique interactions between players as well as a 'hard mode' spawn for added challenge.

## Changelog
:cl:
add: Adds the Stowaway Trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
