### PR TITLE
Tappable Signs

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3453,6 +3453,7 @@
 #include "monkestation\code\datums\diseases\advance\symptoms\rodman.dm"
 #include "monkestation\code\datums\traits\negative.dm"
 #include "monkestation\code\game\area\Space_Station_13_areas.dm"
+#include "monkestation\code\game\objects\structures\signs\_signs.dm"
 #include "monkestation\code\modules\clothing\head\misc_special.dm"
 #include "monkestation\code\modules\clothing\masks\miscellaneous.dm"
 #include "monkestation\code\modules\clothing\suits\labcoat.dm"

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -103,14 +103,17 @@
 		return
 	if(ruined)
 		return
-	visible_message("[user] rips [src] in a single, decisive motion!" )
-	playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
+	//MonkeStation Edit
+	//Requires Harm Intent to rip a poster.
+	if(user.a_intent == INTENT_HARM)
+		visible_message("[user] rips [src] in a single, decisive motion!" )
+		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
+		var/obj/structure/sign/poster/ripped/R = new(loc)
+		R.pixel_y = pixel_y
+		R.pixel_x = pixel_x
+		R.add_fingerprint(user)
+		qdel(src)
 
-	var/obj/structure/sign/poster/ripped/R = new(loc)
-	R.pixel_y = pixel_y
-	R.pixel_x = pixel_x
-	R.add_fingerprint(user)
-	qdel(src)
 
 /obj/structure/sign/poster/proc/roll_and_drop(loc)
 	pixel_x = 0

--- a/monkestation/code/game/objects/structures/signs/_signs.dm
+++ b/monkestation/code/game/objects/structures/signs/_signs.dm
@@ -1,0 +1,20 @@
+/obj/structure/sign
+	//Scaling Posters
+	var/size = 1
+
+/obj/structure/sign/attack_hand(mob/user)
+	//Scaling Posters
+	if(user.a_intent == INTENT_HELP)
+		add_fingerprint(user)
+		visible_message("<span class='warning'>[pick("[user] taps the sign.", "[user] stares intently as they tap that sign.", "Don't make [user] tap that sign again.")]</span>")
+		var/matrix/M = new
+		M.Scale(size*0.25+1)
+		animate(src, transform = M, time = 5)
+		playsound(src, 'sound/effects/Glassknock.ogg', 50, 1)
+		user.changeNext_move(CLICK_CD_MELEE)
+		spawn(1 SECONDS)
+			if(size)
+				var/scaled = 100/(100+((size*0.25)*100))
+				M.Scale(scaled)
+				animate(src, transform = M, time = 5)
+				size++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All objects under /obj/structure/sign can now be tapped to increase their size temporally, the size increasing with each tap upon the sign. 
This also changes posters to only get torn down when on Harm intent.

## Why It's Good For The Game

Besides the simple meme potential of "don't make me tap that sign again", this could be possibly useful to indicate a zone or a room to a newer player as it is more easily noticed than a point.

## Changelog
:cl:
add: Signs and posters can be tapped on help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
