### PR TITLE
Moth Herding

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3447,6 +3447,7 @@
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "monkestation\code\_HELPERS\unsorted.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\fermentation.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\gateway.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\goat.dm"

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -116,6 +116,8 @@
 	flash_lighting_fx(FLASH_LIGHT_RANGE, light_power, light_color)
 	last_flash = world.time
 	use_power(1000)
+	//MonkeStation Edit: Moths are flung towards flashers.
+	Grab_Moths(get_turf(src), 3)
 
 	for (var/mob/living/L in hearers(range, src))
 		if(L.flash_act(affect_silicon = 1))

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -79,13 +79,10 @@
 			setting_text = "standard lighting"
 		if(4)
 			setting_text = "high power"
-			//MonkeStation Edit Start
-			//Moths are flung at lamps
-			Grab_Moths(get_turf(src))
+			Grab_Moths(get_turf(src))			//MonkeStation Edit: Moths are flung at lamps
 	if(user)
 		to_chat(user, "You set [src] to [setting_text].")
-		user.changeNext_move(CLICK_CD_MELEE)
-			//MonkeStation Edit End
+		user.changeNext_move(CLICK_CD_MELEE) 	//MonkeStation Edit: Adds cooldown to floodlight mode changes.
 
 /obj/machinery/power/floodlight/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_WRENCH)

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -79,8 +79,13 @@
 			setting_text = "standard lighting"
 		if(4)
 			setting_text = "high power"
+			//MonkeStation Edit Start
+			//Moths are flung at lamps
+			Grab_Moths(get_turf(src))
 	if(user)
 		to_chat(user, "You set [src] to [setting_text].")
+		user.changeNext_move(CLICK_CD_MELEE)
+			//MonkeStation Edit End
 
 /obj/machinery/power/floodlight/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_WRENCH)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -121,6 +121,8 @@
 	orbitsize -= (orbitsize / world.icon_size) * (world.icon_size * 0.25)
 
 	EB.orbit(src, orbitsize, pick(FALSE, TRUE), rand(10, 25), pick(3, 4, 5, 6, 36))
+	//MonkeStation Edit: Moths leap for teslas
+	Grab_Moths(get_turf(EB), 10)
 
 
 /obj/singularity/energy_ball/Bump(atom/A)

--- a/monkestation/code/_HELPERS/unsorted.dm
+++ b/monkestation/code/_HELPERS/unsorted.dm
@@ -1,0 +1,5 @@
+/proc/Grab_Moths(turf/T, range = 6, speed = 0.5) //For all your moth grabbing needs.
+	for(var/mob/living/carbon/human/H in oview(range, T))
+		if(ismoth(H) && isliving(H))
+			pick(H.emote("scream"), H.visible_message("<span class='boldwarning'>[H] lunges for the light!</span>"))
+			H.throw_at(T, range, speed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the Grab_Moths global proc that will cause all living moths in a chosen radius to fly towards the turf provided.
Has range and speed variables for different intensities.

The Mobile/Wall Flasher and Floodlight trigger this proc and tesla balls trigger it upon creation of a new mini-ball.
The Floodlight has been given a cooldown per switch to prevent a perma-stun.

## Why It's Good For The Game

Moth memes. I have no other reasoning.

## Changelog
:cl:
add: Moths lunge for powerful lamps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
