### PR TITLE
Sign Size Cap

### DIFF
--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -32,7 +32,9 @@
 				var/scaled = 100/(100+((size*0.25)*100))
 				M.Scale(scaled)
 				animate(src, transform = M, time = 5)
-				size++
+				size = min(size+1, 10)
+				spawn(2 MINUTES) //Slowly resets the size back to normal
+					size = max(size-1, 1)
 //MonkeStation Edit End
 
 /obj/structure/sign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives signs a maximum size and causes them to slowly return to their initial size after tapping them.

## Why It's Good For The Game

Signs were filling up the screen due to very eager tapping, now they cap out at roughly 3x the size.

## Changelog
:cl:
tweak: Signs have a maximum size and return to normal over time.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
