### PR TITLE
Bad Food Disease

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -493,7 +493,7 @@
 //MonkeStation Edit: Bad Food can cause disease
 /datum/reagent/toxin/bad_food/reaction_mob(mob/living/M, method = INGEST, reac_volume, show_message, touch_protection)
 	. = ..()
-	if((ishuman(M) || ismonkey(M)) && prob(20))
+	if(prob(20) && (ishuman(M) || ismonkey(M))
 		var/datum/disease/advance/plague = new /datum/disease/advance/random(rand(2,3), 9, 0, /datum/symptom/vomit)
 		plague.name = "Food Poisoning"
 		plague.try_infect(M)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -493,7 +493,7 @@
 //MonkeStation Edit: Bad Food can cause disease
 /datum/reagent/toxin/bad_food/reaction_mob(mob/living/M, method = INGEST, reac_volume, show_message, touch_protection)
 	. = ..()
-	if(prob(20) && (ishuman(M) || ismonkey(M))
+	if(prob(20) && (ishuman(M) || ismonkey(M)))
 		var/datum/disease/advance/plague = new /datum/disease/advance/random(rand(2,3), 9, 0, /datum/symptom/vomit)
 		plague.name = "Food Poisoning"
 		plague.try_infect(M)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -490,6 +490,15 @@
 	toxpwr = 0.5
 	taste_description = "bad cooking"
 
+//MonkeStation Edit: Bad Food can cause disease
+/datum/reagent/toxin/bad_food/reaction_mob(mob/living/M, method = INGEST, reac_volume, show_message, touch_protection)
+	. = ..()
+	if((ishuman(M) || ismonkey(M)) && prob(20))
+		var/datum/disease/advance/plague = new /datum/disease/advance/random(rand(2,3), 9, 0, /datum/symptom/vomit)
+		plague.name = "Food Poisoning"
+		plague.try_infect(M)
+//MonkeStation Edit End
+
 /datum/reagent/toxin/itching_powder
 	name = "Itching Powder"
 	description = "A powder that induces itching upon contact with the skin. Causes the victim to scratch at their itches and has a very low chance to decay into Histamine."


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bad Food, found in failed burnt mess recipes, now has a 20% chance to infect the subject with a 1-3 symptom disease that will always include vomiting.

## Why It's Good For The Game

The chef's failures shall be punished.

## Changelog
:cl:
add: Burnt messes can now get you sick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
