### PR TITLE
Preferences character preview bugfix, moth wing bugfixes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1977,8 +1977,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		pref_species = new /datum/species/human
 		save_character()
 
-	character.dna.features = features.Copy()
 	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
+	character.dna.features = features.Copy()
 	character.dna.real_name = character.real_name
 
 	if("tail_lizard" in pref_species.default_features)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1977,6 +1977,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		pref_species = new /datum/species/human
 		save_character()
 
+	character.dna.features = features.Copy()
 	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 	character.dna.features = features.Copy()
 	character.dna.real_name = character.real_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1979,7 +1979,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	character.dna.features = features.Copy()
 	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
-	character.dna.features = features.Copy()
+	character.dna.features = features.Copy() //MonkeStation Edit: Character generation bugfix
+
 	character.dna.real_name = character.real_name
 
 	if("tail_lizard" in pref_species.default_features)

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1983,6 +1983,7 @@
 	name = "Snow"
 	icon_state = "snow"
 
+/*
 /datum/sprite_accessory/moth_wings/angel
 	name = "Angel"
 	icon_state = "angel"
@@ -1991,6 +1992,7 @@
 	center = TRUE
 	dimension_y = 34
 	locked = TRUE
+*/
 
 // IPC accessories.
 

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1983,7 +1983,7 @@
 	name = "Snow"
 	icon_state = "snow"
 
-/*
+/* MonkeStation Edit: Commented out nonexistent moth wing
 /datum/sprite_accessory/moth_wings/angel
 	name = "Angel"
 	icon_state = "angel"

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -107,7 +107,7 @@
 	icon_state = "mothwings"
 	flight_level = WINGS_FLIGHTLESS
 	basewings = "moth_wings"
-	wing_type = "plain"
+	wing_type = "Plain"
 	canopen = FALSE
 
 /obj/item/organ/wings/moth/robust

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -107,7 +107,7 @@
 	icon_state = "mothwings"
 	flight_level = WINGS_FLIGHTLESS
 	basewings = "moth_wings"
-	wing_type = "Plain"
+	wing_type = "Plain" //MonkeStation Edit: Moth Wing Bugfix
 	canopen = FALSE
 
 /obj/item/organ/wings/moth/robust


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes three bugs:
1. Certain features of certain species no longer disappear any time the preferences window is updated.
2. A moth wing style called Angel that had no associated sprite has been commented out.
3. Moth wings are now initialized with wing_type Plain rather than plain, as plain does not exist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It was really annoying to fight the preferences menu to see what wings looked like!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Moth wings, lizard spines, and lizard tails no longer disappear in the preferences menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
