### PR TITLE
ERTs are now any race by default (except plasmamen)

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -3,7 +3,7 @@
 	var/team = /datum/team/ert
 	var/opendoors = TRUE
 	var/leader_role = /datum/antagonist/ert/commander
-	var/enforce_human = TRUE
+	var/enforce_human = FALSE //MONKESTATION EDIT - ERTs are no longer human by default
 	var/roles = list(/datum/antagonist/ert/security, /datum/antagonist/ert/medic, /datum/antagonist/ert/engineer) //List of possible roles to be assigned to ERT members.
 	var/rename_team
 	var/code

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -388,7 +388,7 @@
 				ERTOperative.key = chosen_candidate.key
 				log_objective(ERTOperative, missionobj.explanation_text)
 
-				if(ertemplate.enforce_human || !(ERTOperative.dna.species.changesource_flags & ERT_SPAWN)) // Don't want any exploding plasmemes
+				if(ertemplate.enforce_human || !(ERTOperative.dna.species.changesource_flags & ERT_SPAWN) || isplasmaman(ERTOperative)) // Don't want any exploding plasmemes //MONKESTATION EDIT - ONLY PLASMAMEN GET FORCED TO BE HUMAN
 					ERTOperative.set_species(/datum/species/human)
 
 				//Give antag datum


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Flips a TRUE to a FALSE to allow ERTs to be any race by default, except plasmamen so that they don't spontaneously combust.

## Why It's Good For The Game

I'd like to be able to play my character's race when literally everything else is carried over

## Changelog
:cl:
tweak: ERTs can now be nearly any race
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
