### PR TITLE
Adds bald trait, makes wigs wearable in the neck slot

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3463,6 +3463,7 @@
 #include "monkestation\code\datums\diseases\advance\symptoms\goat.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\rodman.dm"
 #include "monkestation\code\datums\traits\negative.dm"
+#include "monkestation\code\datums\traits\neutral.dm"
 #include "monkestation\code\game\area\Space_Station_13_areas.dm"
 #include "monkestation\code\game\objects\effects\misc.dm"
 #include "monkestation\code\game\objects\items\stickables.dm"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -97,3 +97,21 @@
 
 /datum/quirk/monochromatic/remove()
 	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+
+//MonkeStation Edit Start - Bald Quirk
+/datum/quirk/bald
+	name = "Bald"
+	desc = "Your hair seems to have gone missing. Luckily, you will spawn with a wig."
+	value = 0
+
+/datum/quirk/bald/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/head/wig/W = new /obj/item/clothing/head/wig
+	W.hair_color = "#[H.hair_color]"
+	W.hair_style = H.hair_style
+	log_world(H.hair_color)
+	log_world(H.hair_style)
+	H.equip_to_slot_if_possible(W, ITEM_SLOT_BACKPACK)
+	W.update_icon()
+	H.dna.species.go_bald(H)
+//Monkestation Edit End

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -106,7 +106,7 @@
 
 /datum/quirk/bald/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/head/wig/W = new /obj/item/clothing/head/wig
+	var/obj/item/clothing/head/wig/W = new
 	W.hair_color = "#[H.hair_color]"
 	W.hair_style = H.hair_style
 	log_world(H.hair_color)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -97,21 +97,3 @@
 
 /datum/quirk/monochromatic/remove()
 	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
-
-//MonkeStation Edit Start - Bald Quirk
-/datum/quirk/bald
-	name = "Bald"
-	desc = "Your hair seems to have gone missing. Luckily, you will spawn with a wig."
-	value = 0
-
-/datum/quirk/bald/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/head/wig/W = new
-	W.hair_color = "#[H.hair_color]"
-	W.hair_style = H.hair_style
-	log_world(H.hair_color)
-	log_world(H.hair_style)
-	H.equip_to_slot_if_possible(W, ITEM_SLOT_BACKPACK)
-	W.update_icon()
-	H.dna.species.go_bald(H)
-//Monkestation Edit End

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -267,8 +267,14 @@
 		. += M
 
 /obj/item/clothing/head/wig/attack_self(mob/user)
-	var/new_style = input(user, "Select a hair style", "Wig Styling")  as null|anything in (GLOB.hair_styles_list - "Bald")
+	var/new_style = input(user, "Select a hair style", "Wig Styling")  as null|anything in (GLOB.hair_styles_list + "Random")
 	if(!user.canUseTopic(src, BE_CLOSE))
+		return
+	if(new_style == "Random") //Monkestation Edit: Adds random option
+		hair_style = pick(GLOB.hair_styles_list)
+		if(adjustablecolor)
+			hair_color = "#[random_color()]"
+		update_icon()
 		return
 	if(new_style && new_style != hair_style)
 		hair_style = new_style

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -234,6 +234,7 @@
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
 	icon_state = "hair_vlong"
 	item_state = "pwig"
+	slot_flags = ITEM_SLOT_HEAD | ITEM_SLOT_NECK //MonkeStation Edit: Wigs are now wearable in neck slots
 	flags_inv = HIDEHAIR
 	var/hair_style = "Very Long Hair"
 	var/hair_color = "#000"

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -90,12 +90,8 @@
 	name = "Ahoge"
 	icon_state = "hair_antenna"
 
-/datum/sprite_accessory/hair/bald
+/datum/sprite_accessory/hair/bald //Monkestation edit: Removes bald, changes bald2 to bald. for Bald quirk
 	name = "Bald"
-	icon_state = null
-
-/datum/sprite_accessory/hair/bald2
-	name = "Bald 2"
 	icon_state = "hair_bald2"
 
 /datum/sprite_accessory/hair/balding

--- a/monkestation/code/datums/traits/neutral.dm
+++ b/monkestation/code/datums/traits/neutral.dm
@@ -1,0 +1,15 @@
+/datum/quirk/bald
+	name = "Bald"
+	desc = "Your hair seems to have gone missing. Luckily, you will spawn with a wig."
+	value = 0
+
+/datum/quirk/bald/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/head/wig/W = new
+	W.hair_color = "#[H.hair_color]"
+	W.hair_style = H.hair_style
+	log_world(H.hair_color)
+	log_world(H.hair_style)
+	H.equip_to_slot_if_possible(W, ITEM_SLOT_BACKPACK)
+	W.update_icon()
+	H.dna.species.go_bald(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a 0-point Bald quirk, which makes you bald and spawns you with a wig. This wig mimics your character preferences' hair style by default.
Additionally, this removes the "Bald" hairstyle. The "Bald 2" hairstyle has been kept and renamed to Bald.
This also makes wigs wearable in the neck slot as well as the head slot.
The wig styling menu also gains a "Random" option that selects a random hair style and color.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows for people who previously used the bald hairstyle to spawn with a wig if they want to use one, and allows for mutantraces that normally don't have hair to have a wig roundstart.
This PR also makes wigs more convincing, as you can now wear wigs with hats.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a new quirk, Bald.
tweak: Wigs can now be worn in both the head slot and the neck slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
