### PR TITLE
Low-Pop Access Boost

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -196,7 +196,7 @@
 
 	//Equip the rest of the gear
 	H.dna.species.before_equip_job(src, H, visualsOnly)
-	
+
 	if(src.species_outfits)
 		if(H.dna.species.id in src.species_outfits)
 			var/datum/outfit/O = species_outfits[H.dna.species.id]
@@ -221,6 +221,11 @@
 		. = src.minimal_access.Copy()
 	else
 		. = src.access.Copy()
+		//MonkeStation Edit: Lowpop Basic Access
+		. += list(	ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_RESEARCH,
+					ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION, ACCESS_MINERAL_STOREROOM, ACCESS_MEDICAL, ACCESS_CARGO, ACCESS_ROBOTICS,
+					ACCESS_SURGERY, ACCESS_CLONING, ACCESS_MECH_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MAINT_TUNNELS)
+		//MonkeStation Edit End
 
 	if(CONFIG_GET(flag/everyone_has_maint_access)) //Config has global maint access set
 		. |= list(ACCESS_MAINT_TUNNELS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This causes further access to be granted upon low population stations, giving players options to choose the job they wanted to play while also still giving the station a chance at functionality.

Accesses Granted to all players:

**Medical:**
Medbay
Surgery
Cloning

**Engineering:**
External Airlocks(Solars)
Tech Storage
Engineering
Engineering equipment
Construction
Maintenance

**Cargo:**
Cargo
Mining
Mining Base
Mineral Storage

**Science:**
Research
Robotics(Needed for R&D)

_**This may require a config update to change the maximum population before skeletal crew is disabled!**_

## Why It's Good For The Game

In a low population situation, this means that players will have options to keep the station running that doesn't involve tiding the spare.

## Changelog
:cl:
tweak: All job ID cards are granted more access when the station is in skeletal mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
