### PR TITLE
Passive Discovery Research

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -75,5 +75,7 @@
 	TECHWEB_POINT_TYPE_DISCOVERY = "Discovery Research",\
 	TECHWEB_POINT_TYPE_NANITES = "Nanite Research"\
 	)
-
+//MonkeStation Edit: Passive Discovery Research
+GLOBAL_VAR_INIT(passive_discovery_research, 16)
+//MonkeStation Edit End
 #define TECHWEB_BOMB_POINTCAP		50000 //! Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -79,6 +79,9 @@ SUBSYSTEM_DEF(research)
 		for(var/i in bitcoins)
 			bitcoins[i] *= income_time_difference / 10
 		science_tech.add_point_list(bitcoins)
+		//MonkeStation Edit: Passive Discovery Research
+		science_tech.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, GLOB.passive_discovery_research)
+		//MonkeStation Edit End
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
@@ -46,7 +46,7 @@
 	//Handle payout
 	SSeconomy.distribute_funds(payout)
 	GLOB.exploration_points += payout * 0.1
-	GLOB.passive_discovery_research += 6
+	GLOB.passive_discovery_research += 6 //MonkeStation Edit: Passive Discovery Research per mission
 	//Announcement
 	//MonkeStation Edit: Missions increase Discovery Research
 	priority_announce("Central Command priority objective completed. [payout] credits have been \

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
@@ -46,8 +46,10 @@
 	//Handle payout
 	SSeconomy.distribute_funds(payout)
 	GLOB.exploration_points += payout * 0.1
+	GLOB.passive_discovery_research += 6
 	//Announcement
+	//MonkeStation Edit: Missions increase Discovery Research
 	priority_announce("Central Command priority objective completed. [payout] credits have been \
-		distributed across departmental budgets. [payout * 0.1] points have been distrubted to exploration vendors.", "Central Command Report", SSstation.announcer.get_rand_report_sound())
+		distributed across departmental budgets. [payout * 0.1] points have been distrubted to exploration vendors.\nPassive Discovery Research Increased.", "Central Command Report", SSstation.announcer.get_rand_report_sound())
 	//Delete
 	QDEL_NULL(SSorbits.current_objective)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Provides a constant flow of 16 discovery points every second, increased by 6 for every exploration mission completed.

Example 5,000 point research with number of exploration missions done & time to passively research it.
0 Mission: 5.2 minutes
1 mission: 3.8 minutes
2 missions: 3 minutes
3 missions: 2.5 minutes
4 missions: 2.1 minutes
5 missions: 1.8 minutes
6 missions: 1.6 minutes

## Why It's Good For The Game

The Exploration system, while a good idea, was jammed into the game and promptly abandoned.
The creator never accounted for rounds without a full exploration team, or explorers that do not play as intended by scanning down everything they can.

This deals with these issues by giving a very small trickle of discovery at all times.
The amount of research is incredibly small, but even the most baseline activity from exploration or science can increase it substantially.

## Changelog
:cl:
add: There is now passive Discovery Research, boosted by doing Exploration Missions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
